### PR TITLE
Add BBCountUnique. 

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -26,6 +26,9 @@ if config["qc_reads"]:
 if config["remove_human"]:
     include: "rules/preproc/remove_human.smk"
 
+if config["assess_depth"]:
+    include: "rules/preproc/bbcountunique.smk"
+
 #############################
 # Naive sample comparison
 #############################

--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,7 @@ dbdir: "databases"       # Databases will be downloaded to this dir, if requeste
 #########################
 qc_reads: True
 remove_human: True
+assess_depth: True
 sketch_compare: False
 mappers:
     bbmap: False
@@ -35,7 +36,7 @@ antibiotic_resistance: False
 
 
 #########################
-# Read quality assessment
+# Preprocessing
 #########################
 bbduk:
     minlen: 30
@@ -48,7 +49,7 @@ bbduk:
     trimbyoverlap: "trimbyoverlap"
     trimpairsevenly: "trimpairsevenly"
 remove_human:
-    hg19_path: ""        # [Required] Path to folder containing the BBMap index for hg19
+    hg19_path: ""         # [Required] Path to folder containing the BBMap index for hg19
     minid: 0.95
     maxindel: 3
     minhits: 2
@@ -59,6 +60,8 @@ remove_human:
     quickmatch: "quickmatch"
     fast: "fast"
     untrim: "untrim"
+bbcountunique:
+    interval: 5000        # Typically set to 10000, but test data requires <=5035
 
 #########################
 # Mappers

--- a/envs/bbmap.yaml
+++ b/envs/bbmap.yaml
@@ -3,4 +3,5 @@ channels:
     - conda-forge
     - defaults
 dependencies:
+    - pandas =0.22.0
     - bbmap =37.90

--- a/rules/preproc/bbcountunique.smk
+++ b/rules/preproc/bbcountunique.smk
@@ -1,0 +1,35 @@
+# vim: syntax=python expandtab
+# Assess sequencing depth of sample using BBCountUnique from the BBMap suite.
+import os.path
+
+# Add final output files from this module to 'all_outputs' from
+# the main Snakefile scope. SAMPLES is also from the main Snakefile scope.
+bcu_output = expand("{outdir}/bbcountunique/{sample}.{output_type}",
+        outdir=config["outdir"],
+        sample=SAMPLES,
+        output_type=["bbcountunique.txt", "bbcountunique.pdf"])
+all_outputs.extend(bcu_output)
+
+rule bbcountunique:
+    """Assess sequencing depth using BBCountUnique."""
+    input:
+        os.path.join(config["inputdir"], config["input_fn_pattern"]).format(sample="{sample}", readpair="1")
+    output:
+        txt=config["outdir"]+"/bbcountunique/{sample}.bbcountunique.txt",
+        pdf=config["outdir"]+"/bbcountunique/{sample}.bbcountunique.pdf",
+    log:
+        stdout=config["outdir"]+"/logs/bbcountunique/{sample}.bbcountunique.stdout.log",
+        stderr=config["outdir"]+"/logs/bbcountunique/{sample}.bbcountunique.stderr.log",
+    shadow: 
+        "shallow"
+    threads:
+        2
+    conda:
+        "../../bbmap.yaml",
+    params:
+        interval=config["bbcountunique"]["interval"]
+    shell:
+        """
+        bbcountunique.sh in={input} out={output.txt} interval={params.interval} > {log.stdout} 2> {log.stderr}
+        scripts/plot_bbcountunique.py {output.txt} {output.pdf} >> {log.stdout} 2>> {log.stderr}
+        """

--- a/scripts/plot_bbcountunique.py
+++ b/scripts/plot_bbcountunique.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# (c) Fredrik Boulund 2017
+"""Plot BBCountUnique histogram"""
+
+from sys import argv, exit
+import os
+import argparse
+
+import matplotlib as mpl
+mpl.use("Agg")
+
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("histogram_data", help="bbcountunique.sh default output format.")
+    parser.add_argument("output_file", help="Filename for plot output.")
+    if len(argv) < 2:
+        parser.print_help()
+        exit(1)
+    return parser.parse_args()
+
+
+def plot_histogram(histogram_data_file, output_image):
+    """Plot a histogram for a sample.
+    """
+    sample_name = os.path.basename(histogram_data_file).split(".", maxsplit=1)[0]
+    df = pd.read_table(histogram_data_file, index_col=0)
+
+    fig, ax  = plt.subplots(figsize=(10,7))
+    df["first"].plot(ax=ax)
+    ax.set_title("{sample}\nKmer saturation (BBCountUnique)".format(sample=sample_name))
+    ax.set_xlabel("Sampled reads")
+    ax.set_ylabel("Proportion novel kmers observed")
+    ax.set_ylim([0,100])
+    fig.savefig(output_image)
+
+
+if __name__ == "__main__":
+    options = parse_args()
+    plot_histogram(options.histogram_data, options.output_file)


### PR DESCRIPTION
This PR adds a preprocessing step for assessing the sequencing depth of samples, and thus closes #15. 

The PR also modifies the BBMap env to include pandas, required for plotting the results. I added `assess_depth` as a step that is on by default, because it doesn't have any dependencies outside of what is already required for the previous preprocessing steps, and is light on resources and fairly quick to run. 