### PR TITLE
Parameterize container images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ situations.
   removal steps.
 
 ### Changed
+- Moved container specifications into config file. Now using more detailed
+  container specifications for most rules. This also enables easier use of
+  local copies of containers (e.g. in HPC environments without external network
+  access).
   
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ situations.
 ### Deprecated
 
 ### Removed
-- Removed mentions of assembly workflow from docs.
+- Removed mentions of assembly workflow from docs and config.
 
 
 ## [0.7.0] 2023-06-13

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,7 +17,6 @@ input_fn_pattern: "{sample}_{readpair}.fq.gz"
 samplesheet: ""           # Three-column samplesheet with sample_id,fastq_1,fastq_2 columns. Used instead of inputdir
 outdir: "output_dir"
 logdir: "output_dir/logs"
-dbdir: "databases"        # Databases will be downloaded to this dir
 report: "StaG_report-"    # Filename prefix for report file ("-{datetime}.html" automatically appended)
 email: ""                 # Email to send status message after completed/failed run.
 
@@ -27,6 +26,25 @@ email: ""                 # Email to send status message after completed/failed 
 #########################
 s3_endpoint_url: "https://s3.ki.se"  # Use https://s3.amazonaws.com for Amazon S3
 keep_local: False                    # Keep local copies of remote input files, default False.
+
+
+#########################
+# Container images
+#########################
+containers:
+    bbmap: "docker://quay.io/biocontainers/bbmap:39.06--h92535d8_0"
+    bowtie2: "docker://quay.io/biocontainers/bowtie2:2.5.1--py38he00c5e5_2"
+    bracken: "docker://quay.io/biocontainers/bracken:2.9--py39h1f90b4d_0"
+    fastp: "docker://quay.io/biocontainers/fastp:0.23.4--hadf994f_2"
+    humann: "docker://quay.io/biocontainers/humann:3.8--pyh7cba7a3_0"
+    kaiju: "docker://quai.io/biocontainers/kaiju:1.10.1--h43eeafb_0"
+    kraken2: "docker://quay.io/biocontainers/kraken2:2.1.3--pl5321hdcf5f25_0"
+    krakenuniq: "docker://quay.io/biocontainers/krakenuniq:1.0.4--pl5321h6dccd9a_1"
+    krona: "docker://quay.io/biocontainers/krona:2.8.1--pl5321hdfd78af_1"
+    metaphlan: "docker://quay.io/biocontainers/metaphlan:4.1.0--pyhca03a8a_0"
+    multiqc: "docker://quay.io/biocontainers/multiqc:1.21--pyhdfd78af_0"
+    samtools: "docker://quay.io/biocontainers/samtools:1.19.2--h50ea8bc_1"
+    stag: "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc-develop"
 
 
 #########################
@@ -52,8 +70,6 @@ functional_profile:
 mappers:
     bbmap: False
     bowtie2: False
-assembly: False
-binning: False
 
 
 #########################
@@ -190,8 +206,3 @@ bowtie2:
           attribute_type: ""   # Attribute type to summarize counts for, default is "gene_id" (any attribute in the GTF file's attribute field can be used)
           extra: ""            # Extra featureCount command line parameters
 
-
-#########################
-# Assembly
-#########################
-# Assembly workflow was removed in StaG v0.7.0

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -22,7 +22,6 @@ from scripts.common import UserMessages, SampleSheet
 user_messages = UserMessages()
 
 stag_version = "0.7.1"
-singularity_branch_tag = "-develop"  # Replace with "-master" before publishing new version
 
 configfile: "config/config.yaml"
 report: "report/workflow.rst"
@@ -31,7 +30,6 @@ citations = {publications["StaG"], publications["Snakemake"]}
 INPUTDIR = Path(config["inputdir"])
 OUTDIR = Path(config["outdir"])
 LOGDIR = Path(config["logdir"])
-DBDIR = Path(config["dbdir"])
 all_outputs = []
 
 if config["samplesheet"]:
@@ -99,10 +97,6 @@ include: "rules/functional_profiling/humann.smk"
 #############################
 include: "rules/mappers/bbmap.smk"
 include: "rules/mappers/bowtie2.smk"
-
-#############################
-# Assembly
-#############################
 
 #############################
 # MultiQC

--- a/workflow/envs/humann.yaml
+++ b/workflow/envs/humann.yaml
@@ -5,4 +5,4 @@ channels:
     - bioconda
     - defaults
 dependencies:
-    - humann=3.7
+    - humann=3.8

--- a/workflow/envs/krakenuniq.yaml
+++ b/workflow/envs/krakenuniq.yaml
@@ -4,4 +4,4 @@ channels:
     - bioconda
     - defaults
 dependencies:
-    - krakenuniq =1.0.3
+    - krakenuniq =1.0.4

--- a/workflow/envs/metaphlan.yaml
+++ b/workflow/envs/metaphlan.yaml
@@ -4,5 +4,5 @@ channels:
     - bioconda
     - defaults
 dependencies:
-    - metaphlan =4.0.6
+    - metaphlan =4.1.0
     - krona =2.8.1

--- a/workflow/envs/stag-mwc.yaml
+++ b/workflow/envs/stag-mwc.yaml
@@ -5,21 +5,20 @@ channels:
     - defaults
 dependencies:
     - python =3.10.9
-    - fastp =0.23.2
-    - bbmap =39.01
-    - kaiju =1.9.2
-    - kraken2 =2.1.2
-    - bracken =2.8
+    - bbmap =39.06
+    - bracken =2.9
+    - fastp =0.23.4
+    - kaiju =1.10.1
+    - kraken2 =2.1.3
     - krona =2.8.1
     - matplotlib =3.7.1
-    - multiqc =1.14
+    - multiqc =1.21
     - pandas =2.0.0
+    - pigz =2.6
+    - sambamba =1.0
+    - samtools =1.19.2
     - seaborn =0.12.2
     - subread =2.0.3
-    - sambamba =1.0
-    - samtools =1.6
-    - groot =1.1.2
-    - pigz =2.6
     - pip
     - pip:
         - fastcluster

--- a/workflow/rules/functional_profiling/humann.smk
+++ b/workflow/rules/functional_profiling/humann.smk
@@ -48,7 +48,7 @@ rule humann:
     conda:
         "../../envs/humann.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:biobakery"+singularity_branch_tag
+        config["containers"]["humann"]
     threads: 20
     params:
         outdir=f"{OUTDIR}/humann/",
@@ -96,7 +96,7 @@ rule normalize_humann_tables:
     conda:
         "../../envs/humann.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:biobakery"+singularity_branch_tag
+        config["containers"]["humann"]
     threads: 1
     params:
         method=h_config["norm_method"],
@@ -143,7 +143,7 @@ rule humann_join_tables:
     conda:
         "../../envs/humann.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:biobakery"+singularity_branch_tag
+        config["containers"]["humann"]
     threads: 
         1
     params:
@@ -174,3 +174,4 @@ rule humann_join_tables:
             >> {log.stdout} \
             2>> {log.stderr}
         """
+

--- a/workflow/rules/multiqc/multiqc.smk
+++ b/workflow/rules/multiqc/multiqc.smk
@@ -9,17 +9,17 @@ if config["multiqc_report"]:
         input:
             all_outputs
         output:
-            report=report(f"{OUTDIR}/multiqc/multiqc_report.html",
+            report=report(OUTDIR/"multiqc/multiqc_report.html",
                 category="Sequencing data quality",
                 caption="../../report/multiqc.rst"),
         log:
-           f"{LOGDIR}/multiqc/multiqc.log"
+           LOGDIR/"multiqc/multiqc.log"
         shadow:
             "shallow"
         conda:
             "../../envs/stag-mwc.yaml"
         container:
-            "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+            config["containers"]["multiqc"]
         threads: 1
         params:
             extra=mqc_config["extra"],
@@ -32,4 +32,5 @@ if config["multiqc_report"]:
             """
 
     # Appended after the rule definition to avoid circular dependency
-    all_outputs.append(f"{OUTDIR}/multiqc/multiqc_report.html")
+    all_outputs.append(OUTDIR/"multiqc/multiqc_report.html")
+

--- a/workflow/rules/preproc/host_removal.smk
+++ b/workflow/rules/preproc/host_removal.smk
@@ -56,7 +56,7 @@ if config["host_removal"]["kraken2"]:
         conda:
             "../../envs/stag-mwc.yaml"
         container:
-            "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+            config["containers"]["kraken2"]
         threads: 8
         params:
             db=rh_kraken2["db_path"],
@@ -109,7 +109,7 @@ if config["host_removal"]["kraken2"]:
         conda:
             "../../envs/stag-mwc.yaml"
         container:
-            "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+            config["containers"]["stag"]
         threads: 1
         shell:
             """
@@ -155,7 +155,7 @@ if config["host_removal"]["bowtie2"]:
         conda:
             "../../envs/metaphlan.yaml"
         container:
-            "docker://quay.io/biocontainers/bowtie2:2.5.1--py38he00c5e5_2"
+            config["containers"]["bowtie2"]
         params:
             db_path=rh_bowtie2["db_path"],
             extra=rh_bowtie2["extra"],
@@ -183,7 +183,7 @@ if config["host_removal"]["bowtie2"]:
         conda:
             "../../envs/metaphlan.yaml"
         container:
-            "docker://quay.io/biocontainers/samtools:1.17--hd87286a_1"
+            config["containers"]["samtools"]
         shell:
             """
             samtools view \
@@ -207,7 +207,7 @@ if config["host_removal"]["bowtie2"]:
         conda:
             "../../envs/metaphlan.yaml"
         container:
-            "docker://quay.io/biocontainers/samtools:1.17--hd87286a_1"
+            config["containers"]["samtools"]
         shell:
             """
             samtools view \
@@ -233,7 +233,7 @@ if config["host_removal"]["bowtie2"]:
         conda:
             "../../envs/metaphlan.yaml"
         container:
-            "docker://quay.io/biocontainers/samtools:1.17--hd87286a_1"
+            config["containers"]["samtools"]
         shell: 
             """
             samtools sort \
@@ -259,7 +259,7 @@ if config["host_removal"]["bowtie2"]:
         conda:
             "../../envs/metaphlan.yaml"
         container:
-            "docker://quay.io/biocontainers/samtools:1.17--hd87286a_1"
+            config["containers"]["samtools"]
         shell: 
             """
             samtools fastq \

--- a/workflow/rules/preproc/preprocessing_summary.smk
+++ b/workflow/rules/preproc/preprocessing_summary.smk
@@ -29,7 +29,7 @@ rule preprocessing_summary:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["stag"]
     threads: 1
     params:
         fastp_arg=lambda w: f"--fastp {LOGDIR}/fastp/*.fastp.json" if config["qc_reads"] else "",

--- a/workflow/rules/preproc/read_quality.smk
+++ b/workflow/rules/preproc/read_quality.smk
@@ -33,7 +33,7 @@ if config["qc_reads"]:
         conda:
             "../../envs/stag-mwc.yaml"
         container:
-            "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+            config["containers"]["fastp"]
         threads: 4
         params:
             extra=fastp_config["extra"],

--- a/workflow/rules/taxonomic_profiling/kaiju.smk
+++ b/workflow/rules/taxonomic_profiling/kaiju.smk
@@ -18,7 +18,6 @@ if config["taxonomic_profile"]["kaiju"]:
                 Path(kaiju_config["names"]).exists()]):
         err_message = "No Kaiju database files at: '{}', '{}', '{}'!\n".format(kaiju_config["db"], kaiju_config["nodes"], kaiju_config["names"])
         err_message += "Specify relevant paths in the kaiju section of config.yaml.\n"
-        err_message += "Run 'snakemake download_kaiju_database' to download a copy into '{dbdir}'\n".format(dbdir=DBDIR/"kaiju") 
         err_message += "If you do not want to run Kaiju for taxonomic profiling, set 'kaiju: False' in config.yaml"
         raise WorkflowError(err_message)
 
@@ -56,7 +55,7 @@ rule kaiju:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["kaiju"]
     params:
         db=kaiju_config["db"],
         nodes=kaiju_config["nodes"],
@@ -86,7 +85,7 @@ rule kaiju2krona:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["kaiju"]
     shell:
         """
         kaiju2krona \
@@ -109,7 +108,7 @@ rule create_kaiju_krona_plot:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["krona"]
     shell:
         """
         ktImportText \
@@ -132,7 +131,7 @@ rule kaiju_report:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["kaiju"]
     shell:
         """
         kaiju2table \
@@ -163,7 +162,7 @@ rule join_kaiju_reports:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["stag"]
     shell:
         """
         workflow/scripts/join_tables.py \
@@ -187,7 +186,7 @@ rule kaiju_area_plot:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["stag"]
     shell:
         """
         workflow/scripts/area_plot.py \

--- a/workflow/rules/taxonomic_profiling/krakenuniq.smk
+++ b/workflow/rules/taxonomic_profiling/krakenuniq.smk
@@ -54,7 +54,7 @@ rule krakenuniq_merge_reads:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["bbmap"]
     shell:
         """
         fuse.sh \
@@ -80,7 +80,7 @@ rule krakenuniq:
     conda:
         "../../envs/krakenuniq.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:krakenuniq"+singularity_branch_tag
+        config["containers"]["krakenuniq"]
     params:
         db=krakenuniq_config["db"],
         preload_size=krakenuniq_config["preload_size"],
@@ -114,7 +114,7 @@ rule krakenuniq_combine_reports:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["stag"]
     shell:
         """
         workflow/scripts/join_tables.py \
@@ -139,7 +139,7 @@ rule krakenuniq_mpa_style:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["stag"]
     shell:
         """
         workflow/scripts/KrakenTools/kreport2mpa.py \
@@ -165,7 +165,7 @@ rule krakenuniq_join_mpa:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["stag"]
     params:
         value_column="reads",
         feature_column="taxon_name",
@@ -195,7 +195,7 @@ rule krakenuniq_kreport2krona:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["stag"]
     shell:
         """
         awk -v OFS='\\t' '{{
@@ -220,7 +220,7 @@ rule krakenuniq_krona_plot:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["krona"]
     shell:
         """
 		ktImportText \

--- a/workflow/rules/taxonomic_profiling/metaphlan.smk
+++ b/workflow/rules/taxonomic_profiling/metaphlan.smk
@@ -56,7 +56,7 @@ rule metaphlan:
     conda:
         "../../envs/metaphlan.yaml"
     container:
-        "docker://quay.io/biocontainers/metaphlan:4.0.6--pyhca03a8a_0"
+        config["containers"]["metaphlan"]
     threads: 8
     params:
         bt2_db_dir=mpa_config["bt2_db_dir"],
@@ -118,7 +118,7 @@ rule combine_metaphlan_tables:
     conda:
         "../../envs/metaphlan.yaml"
     container:
-        "docker://quay.io/biocontainers/metaphlan:4.0.6--pyhca03a8a_0"
+        config["containers"]["metaphlan"]
     threads: 1
     shell:
         """
@@ -139,7 +139,7 @@ rule metaphlan_area_plot:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["stag"]
     shell:
         """
         workflow/scripts/area_plot.py \
@@ -165,7 +165,7 @@ rule plot_metaphlan_heatmap:
     conda:
         "../../envs/stag-mwc.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["stag"]
     threads: 1
     params:
         outfile_prefix=lambda w: f"{OUTDIR}/metaphlan/all_samples",
@@ -206,7 +206,7 @@ rule create_metaphlan_krona_plots:
     conda:
         "../../envs/metaphlan.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
+        config["containers"]["krona"]
     threads: 1
     shell:
         """

--- a/workflow/rules/taxonomic_profiling/strainphlan.smk
+++ b/workflow/rules/taxonomic_profiling/strainphlan.smk
@@ -45,7 +45,7 @@ rule consensus_markers:
     conda:
         "../../envs/metaphlan.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:biobakery"+singularity_branch_tag
+        config["containers"]["metaphlan"]
     threads: 8
     params:
         output_dir=f"{OUTDIR}/strainphlan/consensus_markers/{{sample}}"
@@ -73,7 +73,7 @@ rule print_clades:
     conda:
         "../../envs/metaphlan.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:biobakery"+singularity_branch_tag
+        config["containers"]["metaphlan"]
     threads: 8
     params:
         out_dir=f"{OUTDIR}/strainphlan",
@@ -107,7 +107,7 @@ rule extract_markers:
     conda:
         "../../envs/metaphlan.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:biobakery"+singularity_branch_tag
+        config["containers"]["metaphlan"]
     threads: 8
     params:
         clade=spa_config["clade_of_interest"],
@@ -139,7 +139,7 @@ rule strainphlan:
     conda:
         "../../envs/metaphlan.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:biobakery"+singularity_branch_tag
+        config["containers"]["metaphlan"]
     threads: 8
     params:
         clade=spa_config["clade_of_interest"],
@@ -149,7 +149,7 @@ rule strainphlan:
         extra=spa_config["extra"],  # This is extremely useful if you want to include a reference genome
     shell:
         """
-        echo "please compare your clade_of_interest to list of available clades in available_clades.txt" > {log.stderr}
+        echo "Please compare your clade_of_interest to list of available clades in available_clades.txt" > {log.stderr}
 
         strainphlan \
              -s {input.consensus_markers} \


### PR DESCRIPTION
Put container image specifications into config file. Also makes it easier to use local copies of container images e.g. in HPC environments without the ability to run containers directly from remote paths.